### PR TITLE
Update deps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ test.byte
 test.js
 src/.merlin
 runtime/.merlin
+_opam/
+.vscode/

--- a/.merlin
+++ b/.merlin
@@ -1,5 +1,0 @@
-B _build/**
-S src*/**
-S bin/**
-PKG compiler-libs.common ppx_tools.metaquot ppx_type_conv ppx_core js_of_ocaml js_of_ocaml.ppx webtest webtest.js
-FLG -w @A

--- a/ppx_jsobject_conv.opam
+++ b/ppx_jsobject_conv.opam
@@ -15,9 +15,9 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.10.0"}
-  "js_of_ocaml" {>= "3.8.0" & < "3.11.0"}
+  "dune" {>= "2.7"}
+  "js_of_ocaml" {>= "3.8.0"}
   "ppxlib" {>= "0.22.0"}
-  "dune" {>= "2.7" & >= "2"}
   "webtest" {with-test}
   "webtest-js" {with-test}
 ]

--- a/ppx_jsobject_conv.opam
+++ b/ppx_jsobject_conv.opam
@@ -1,5 +1,7 @@
-opam-version: "1.2"
+opam-version: "2.0"
 name: "ppx_jsobject_conv"
+synopsis: "Ppx rewriter for [@@deriving jsobject]"
+description: "Ppx rewriter for [@@deriving jsobject]"
 version: "0.8.0"
 maintainer: "Roma Sokolov <sokolov.r.v@gmail.com>"
 authors: [ "Roma Sokolov <sokolov.r.v@gmail.com>" ]
@@ -12,10 +14,10 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "js_of_ocaml" {>= "2.8"}
-  "ppxlib" {>= "0.5.0"}
-  "ocaml-migrate-parsetree" {>= "0.4"}
-  "dune" {build & >= "1.0"}
-  "webtest" {test}
+  "ocaml" {>= "4.10.0"}
+  "js_of_ocaml" {>= "3.8.0" & < "3.11.0"}
+  "ppxlib" {>= "0.22.0"}
+  "dune" {>= "2.7" & >= "2"}
+  "webtest" {with-test}
+  "webtest-js" {with-test}
 ]
-available: [ ocaml-version >= "4.08.0" ]

--- a/src_test/dune
+++ b/src_test/dune
@@ -1,7 +1,7 @@
 (executable
    (name test)
-    (libraries js_of_ocaml webtest webtest.js)
-    (js_of_ocaml (flags (:standard --linkall +weak.js)))
+   (modes js)
+    (libraries js_of_ocaml webtest webtest-js)
     (preprocess (pps ppx_jsobject_conv)))
 
 (alias


### PR DESCRIPTION
Thanks for building this ppx.

I was attempting to use it in a project with other deps and ran into some package conflict:

```
[ERROR] Package conflict!
  * Incompatible packages:
    - jsoo-react-realworld-example -> jsoo-react -> ppxlib >= 0.23.0
    - jsoo-react-realworld-example -> ppx_jsobject_conv >= 0.8.0 -> ocaml-migrate-parsetree < 2.0.0
```

This PR upgrades deps to more modern versions and removes dep on `ocaml-migrate-parsetree`, which I believe is unnecessary now with ppxlib.

I ran tests with `make test` and they seem to pass fine.

Maybe something about the PR is useful / recoverable :)