### PR TITLE
Ppxlib.0.26.0 compatibility

### DIFF
--- a/ppx_jsobject_conv.opam
+++ b/ppx_jsobject_conv.opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml" {>= "4.10.0"}
   "dune" {>= "2.7"}
   "js_of_ocaml" {>= "3.8.0"}
-  "ppxlib" {>= "0.22.0"}
+  "ppxlib" {>= "0.26.0"}
   "webtest" {with-test}
   "webtest-js" {with-test}
 ]

--- a/src/ppx_jsobject_conv.ml
+++ b/src/ppx_jsobject_conv.ml
@@ -570,10 +570,11 @@ module Jsobject_of_expander = struct
     let make_cd = function
       | {pext_kind; pext_name; pext_loc; pext_attributes } ->
          (match pext_kind with
-          | Pext_decl (cons_args, ctyp) ->
+          | Pext_decl (vars, cons_args, ctyp) ->
              {
                pcd_name = pext_name;
                pcd_args = cons_args;
+               pcd_vars = vars;
                pcd_res = ctyp;
                pcd_loc = pext_loc;
                pcd_attributes = pext_attributes;
@@ -1163,10 +1164,11 @@ module Of_jsobject_expander = struct
     let make_cd = function
       | {pext_kind; pext_name; pext_loc; pext_attributes } ->
          (match pext_kind with
-          | Pext_decl (cons_args, ctyp) ->
+          | Pext_decl (vars, cons_args, ctyp) ->
              {
                pcd_name = pext_name;
                pcd_args = cons_args;
+               pcd_vars = vars;
                pcd_res = ctyp;
                pcd_loc = pext_loc;
                pcd_attributes = pext_attributes;


### PR DESCRIPTION
This is a patch PR to make the PPX compatible with ppxlib.0.26.0 which has bumped the AST to 4.14/5.00.